### PR TITLE
query docs using "labels.testBuildId"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,8 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers"
 
 const argv = yargs(hideBin(process.argv))
-  .scriptName('apm-parser')
-  .usage('Usage: $0 [options]')
-  .example("$0 -s '2022-03-29T01:20:00.000Z'", 'extract apm data starting from date specified')
+  .scriptName('performance-testing-dataset-extractor')
+  .usage('Usage: yarn cli -u <username> -p <password> -c <es_host> -b <testBuildId> -n <journeyName>')
   .options({
     u: {
       alias: 'user',
@@ -21,30 +20,17 @@ const argv = yargs(hideBin(process.argv))
       describe: 'Password',
       type: 'string',
     },
-    s: {
-      alias: 'start',
-      demandOption: true,
-      describe: 'Start Date',
-      type: 'string',
-    },
     c: {
       alias: 'cluster',
       demandOption: false,
-      describe: 'APM Cluster',
-      default: 'https://kibana-ops-e2e-perf.kb.us-central1.gcp.cloud.es.io',
+      describe: 'ES Cluster',
+      default: 'https://kibana-ops-e2e-perf.es.us-central1.gcp.cloud.es.io:9243',
       type: 'string',
     },
-    e: {
-      alias: 'end',
-      demandOption: false,
-      describe: 'End Date',
-      default: new Date().toISOString(),
-      type: 'string',
-    },
-    j: {
-      alias: 'jobId',
+    b: {
+      alias: 'buildId',
       demandOption: true,
-      describe: 'Journey Job Id',
+      describe: 'Journey Build Id',
       default: '',
       type: 'string',
     },
@@ -82,8 +68,8 @@ const argv = yargs(hideBin(process.argv))
 apmParser({
   dir: argv.d,
   type: argv.t,
-  param: { start: argv.s, end: argv.e, journeyName: argv.n, jobId: argv.j, transactionType: argv.tt },
+  param: { journeyName: argv.n, buildId: argv.b, transactionType: argv.tt },
   client: { auth: { username: argv.u, password: argv.p }, baseURL: argv.c },
 })
-  .then(() => console.log('Apm parser finished successfully'))
-  .catch((e) => console.error('Apm parser failed\n', e));
+  .then(() => console.log('Dataset extractor finished successfully'))
+  .catch((e) => console.error('Dataset extractor failed\n', e));

--- a/src/es_client.ts
+++ b/src/es_client.ts
@@ -17,7 +17,7 @@ export function initClient(options: clientOptions) {
 });
 
     return {
-      getTransactions: async function(jobId: string, journeyName: string, startTime: string){
+      getTransactions: async function(buildId: string, journeyName: string){
         const result = await client.search({
           "body": {
             "track_total_hits": true,
@@ -70,7 +70,7 @@ export function initClient(options: clientOptions) {
                             "should": [
                               {
                                 "match_phrase": {
-                                  "labels.testJobId": jobId
+                                  "labels.testBuildId": buildId
                                 }
                               }
                             ],
@@ -90,14 +90,6 @@ export function initClient(options: clientOptions) {
                           }
                         }
                       ]
-                    }
-                  },
-                  {
-                    "range": {
-                      "@timestamp": {
-                        "format": "strict_date_optional_time",
-                        "gte": startTime
-                      }
                     }
                   }
                 ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,8 @@ type CLIParams = {
   dir: string;
   type: string;
   param: {
-    start: string;
-    end: string;
     journeyName: string;
-    jobId: string;
+    buildId: string;
     transactionType: string[];
   };
   client: {
@@ -29,8 +27,8 @@ const apmParser = async ({ param, client }: CLIParams) => {
     password: client.auth.password,
   }
   const esClient = initClient(authOptions);
-  const hits = await esClient.getTransactions(param.jobId, param.journeyName, param.start);
-  if (!hits && hits.length === 0) {
+  const hits = await esClient.getTransactions(param.buildId, param.journeyName);
+  if (!hits || hits.length === 0) {
     throw new Error('No transactions found')
   }
 
@@ -70,7 +68,7 @@ const apmParser = async ({ param, client }: CLIParams) => {
   }
 
   const outputDir = path.resolve('output');
-  const fileName = `${output.journeyName.replace(/ /g,'')}-${param.jobId}.json`
+  const fileName = `${output.journeyName.replace(/ /g,'')}-${param.buildId}.json`
   const filePath = path.resolve(outputDir, fileName);
   if (!existsSync(outputDir)) {
     await fs.mkdir(outputDir);


### PR DESCRIPTION
While testing elastic/kibana/pull/130777 on Buildkite, I realised that `"labels.testJobId"` that we use in query is changing from step to step of the pipeline. So while running extractor in new step we no longer have an actual jobId that was sent in metrics.

As a fix, we can use `"labels.testBuildId"`, that is constant for all steps within each job build. Related change to push `labels.testJobId` will be push in elastic/kibana/pull/130777

I also did small cleanup in cli, since we do not use some arguments.