### PR TITLE
Print warning instead of script failure when no transactions found

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # APM PARSER
 
+## Pre-conditions
+Makes sure to set `testBuildId` and `journeyName` as APM global labels, it is needed to match appropriate transactions.
+
 ## Cli usage
 ```typescript
-yarn cli -u <username> -p <password> -c "https://apm-7-17.es.us-central1.gcp.cloud.es.io:9243" -s 2022-04-12T00:01:00.000Z -j local-90a41a83-90da-487b-a6be-4713a9ad18d8 -n 'My cool journey'
+ yarn cli -u <username> -p <password> -c "https://apm-7-17.es.us-central1.gcp.cloud.es.io:9243" -b "local-90a41a83-90da-487b-a6be-4713a9ad18d8" -n "My cool journey"
 ```
 
 
@@ -10,8 +13,8 @@ yarn cli -u <username> -p <password> -c "https://apm-7-17.es.us-central1.gcp.clo
 
 ```typescript
 apmParser({
-    start: '2022-04-12T00:01:00.000Z',
-    jobId: 'local-90a41a83-90da-487b-a6be-4713a9ad18d8',
+  param: { journeyName: 'My cool journey', buildId: 'local-90a41a83-90da-487b-a6be-4713a9ad18d8'},
+  client: { auth: { username: '<username>', password: '<password>' }, baseURL: '<esCLusterUrl>' },
 })
     .then(console.info)
     .catch(console.error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ const apmParser = async ({ param, client }: CLIParams) => {
   const esClient = initClient(authOptions);
   const hits = await esClient.getTransactions(param.buildId, param.journeyName);
   if (!hits || hits.length === 0) {
-    throw new Error('No transactions found')
+    console.warn(`No transactions found with 'labels.testBuildId=${param.buildId}' and 'labels.journeyName=${param.journeyName}'\n Output file won't be generated`);
+    return;
   }
 
   const source = hits[0]._source;
@@ -58,8 +59,6 @@ const apmParser = async ({ param, client }: CLIParams) => {
     }
   });
 
-  console.log(`Found ${hits.length} hits`);
-
   const output = {
     journeyName,
     kibanaVersion,
@@ -70,6 +69,8 @@ const apmParser = async ({ param, client }: CLIParams) => {
   const outputDir = path.resolve('output');
   const fileName = `${output.journeyName.replace(/ /g,'')}-${param.buildId}.json`
   const filePath = path.resolve(outputDir, fileName);
+
+  console.log(`Found ${hits.length} transactions, output file: ${filePath}`);
   if (!existsSync(outputDir)) {
     await fs.mkdir(outputDir);
   }


### PR DESCRIPTION
There is case when some journeys where skipped in test file (using `.skip`)
Since FTR does not run it, there are no transactions to re-build scalability benchmarks.

This PR will change behaviour so that when there are no transactions for any journey, script prints warning and exits without failure.